### PR TITLE
[REFACTOR] Dropdown 컴포넌트 코드 위치 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,14 @@ import './styles/App.css';
 import { ErrorContextProvider } from './contexts/ErrorContext';
 
 import Main from './pages/Main';
+import { SearchContextProvider } from './contexts/SearchContext';
 
 const App = () => {
   return (
     <ErrorContextProvider>
-      <Main />
+      <SearchContextProvider>
+        <Main />
+      </SearchContextProvider>
     </ErrorContextProvider>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,8 @@
 import './styles/App.css';
 import { ErrorContextProvider } from './contexts/ErrorContext';
+import { SearchContextProvider } from './contexts/SearchContext';
 
 import Main from './pages/Main';
-import { SearchContextProvider } from './contexts/SearchContext';
 
 const App = () => {
   return (

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -44,12 +44,11 @@ const Dropdown = () => {
       })}
       {hasNext && (
         <li className="dropdown-indicator">
-          {hasNext &&
-            (isLoading ? (
-              <TbLoader2 className="input-icon spinner" />
-            ) : (
-              <RxDotsHorizontal className="input-icon" />
-            ))}
+          {isLoading ? (
+            <TbLoader2 className="input-icon spinner" />
+          ) : (
+            <RxDotsHorizontal className="input-icon" />
+          )}
         </li>
       )}
     </ul>

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,3 +1,7 @@
+import { useRef } from 'react';
+import { TbLoader2 } from 'react-icons/tb';
+import { RxDotsHorizontal } from 'react-icons/rx';
+
 import { useSearchDispatch, useSearchState } from '../contexts/SearchContext';
 import DropdownItem from './DropdownItem';
 import useElementInViewport from '../hooks/useElementInViewport';
@@ -6,14 +10,10 @@ import '../styles/Dropdown.css';
 
 const INPUTTEXT_INDEX = -1;
 
-type DropdownProp = {
-  dropdownRef: React.RefObject<HTMLUListElement>;
-  children: React.ReactNode;
-};
-
-const Dropdown = ({ dropdownRef, children }: DropdownProp) => {
-  const { suggestions, activeIndex, inputText, hasNext } = useSearchState();
+const Dropdown = () => {
+  const { suggestions, isLoading, activeIndex, inputText, hasNext } = useSearchState();
   const { goToNextPage } = useSearchDispatch();
+  const dropdownRef = useRef<HTMLUListElement>(null);
 
   const lastItemRef = useElementInViewport<HTMLButtonElement>(goToNextPage);
 
@@ -42,7 +42,16 @@ const Dropdown = ({ dropdownRef, children }: DropdownProp) => {
           </DropdownItem>
         );
       })}
-      {hasNext && <li className="dropdown-indicator">{children}</li>}
+      {hasNext && (
+        <li className="dropdown-indicator">
+          {hasNext &&
+            (isLoading ? (
+              <TbLoader2 className="input-icon spinner" />
+            ) : (
+              <RxDotsHorizontal className="input-icon" />
+            ))}
+        </li>
+      )}
     </ul>
   );
 };

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import { TbLoader2 } from 'react-icons/tb';
 import { RxDotsHorizontal } from 'react-icons/rx';
 
@@ -13,12 +12,11 @@ const INPUTTEXT_INDEX = -1;
 const Dropdown = () => {
   const { suggestions, isLoading, activeIndex, inputText, hasNext } = useSearchState();
   const { goToNextPage } = useSearchDispatch();
-  const dropdownRef = useRef<HTMLUListElement>(null);
 
   const lastItemRef = useElementInViewport<HTMLButtonElement>(goToNextPage);
 
   return (
-    <ul className="dropdown-container" ref={dropdownRef}>
+    <ul className="dropdown-container">
       {inputText.trim().length > 0 && (
         <DropdownItem index={INPUTTEXT_INDEX} isFocus={activeIndex === INPUTTEXT_INDEX}>
           {inputText}

--- a/src/components/InputTodo.tsx
+++ b/src/components/InputTodo.tsx
@@ -2,20 +2,19 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { AxiosError } from 'axios';
 import { TbLoader2 } from 'react-icons/tb';
 import { FiSearch } from 'react-icons/fi';
-import { RxDotsHorizontal } from 'react-icons/rx';
+
 import { createTodo } from '../api/todo';
 import useFocus from '../hooks/useFocus';
 import { useSearchDispatch, useSearchState } from '../contexts/SearchContext';
 import { useTodosDispatch } from '../contexts/TodoContext';
 import { useErrorDispatch } from '../contexts/ErrorContext';
-import Dropdown from './Dropdown';
 
 import '../styles/InputTodo.css';
 
 export const INITIAL_PAGE_NUM = 1;
 
 const InputTodo = () => {
-  const { inputText, isLoading: isSearchLoading, hasNext, currentPage } = useSearchState();
+  const { inputText, isLoading: isSearchLoading, currentPage } = useSearchState();
   const { changeInputText } = useSearchDispatch();
   const [isLoading, setIsLoading] = useState(false);
   const { ref: inputRef, setFocus } = useFocus();
@@ -79,17 +78,6 @@ const InputTodo = () => {
         />
         {currentPage === 1 && isSearchLoading && <TbLoader2 className="input-icon spinner" />}
       </form>
-
-      {inputText && (
-        <Dropdown dropdownRef={dropdownRef}>
-          {hasNext &&
-            (isSearchLoading ? (
-              <TbLoader2 className="input-icon spinner" />
-            ) : (
-              <RxDotsHorizontal className="input-icon" />
-            ))}
-        </Dropdown>
-      )}
     </div>
   );
 };

--- a/src/components/InputTodo.tsx
+++ b/src/components/InputTodo.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { AxiosError } from 'axios';
 import { TbLoader2 } from 'react-icons/tb';
 import { FiSearch } from 'react-icons/fi';
@@ -18,7 +18,6 @@ const InputTodo = () => {
   const { changeInputText } = useSearchDispatch();
   const [isLoading, setIsLoading] = useState(false);
   const { ref: inputRef, setFocus } = useFocus();
-  const dropdownRef = useRef<HTMLUListElement>(null);
   const { addTodo } = useTodosDispatch();
   const { showError } = useErrorDispatch();
 
@@ -28,7 +27,6 @@ const InputTodo = () => {
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     changeInputText(e.target.value);
-    dropdownRef.current?.scrollTo(0, 0);
   };
   const handleSubmit = useCallback(
     async (e: React.FormEvent<HTMLFormElement>) => {

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -4,10 +4,11 @@ import { useEffect } from 'react';
 import Header from '../components/Header';
 import InputTodo from '../components/InputTodo';
 import TodoList from '../components/TodoList';
-import { SearchContextProvider } from '../contexts/SearchContext';
 import ErrorModal from '../components/ErrorModal';
+import Dropdown from '../components/Dropdown';
 
 import { getTodoList } from '../api/todo';
+import { useSearchState } from '../contexts/SearchContext';
 import { useTodosDispatch } from '../contexts/TodoContext';
 import { useErrorDispatch, useErrorState } from '../contexts/ErrorContext';
 
@@ -15,6 +16,7 @@ import '../styles/Main.css';
 
 const Main = () => {
   const { changeTodos } = useTodosDispatch();
+  const { inputText } = useSearchState();
   const { hasError } = useErrorState();
   const { showError } = useErrorDispatch();
 
@@ -32,13 +34,12 @@ const Main = () => {
 
   return (
     <div className="container">
-      <SearchContextProvider>
-        <div className="inner">
-          <Header />
-          <InputTodo />
-          <TodoList />
-        </div>
-      </SearchContextProvider>
+      <div className="inner">
+        <Header />
+        <InputTodo />
+        {inputText && <Dropdown />}
+        <TodoList />
+      </div>
       {hasError && <ErrorModal />}
     </div>
   );

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -35,3 +35,8 @@ body {
 .btn-trash:hover {
   opacity: 0.5;
 }
+
+.input-icon {
+  color: #7d7d7d;
+  font-size: 20px;
+}

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -12,6 +12,11 @@ body {
   height: 100vh;
 }
 
+:root {
+  --error-modal-z-index: 10;
+  --dropdown-z-index: 9;
+}
+
 .spinner {
   animation: spin 1s linear infinite;
   display: flex;

--- a/src/styles/Dropdown.css
+++ b/src/styles/Dropdown.css
@@ -12,6 +12,7 @@
   background-color: white;
   box-shadow: 0px 0px 1px rgba(50, 50, 50, 0.05), 0px 2px 4px rgba(50, 50, 50, 0.1);
   overflow: auto;
+  z-index: var(--dropdown-z-index);
 
   &::-webkit-scrollbar {
     background: transparent;
@@ -24,7 +25,6 @@
     border: 5px solid transparent;
   }
 }
-
 .dropdown-indicator {
   margin-top: 9px;
   width: 100%;

--- a/src/styles/Dropdown.css
+++ b/src/styles/Dropdown.css
@@ -3,8 +3,8 @@
   flex-direction: column;
   align-items: flex-start;
   position: absolute;
-  top: 55px;
-  width: 100%;
+  top: 355px;
+  width: 97%;
   max-height: 170px;
   padding: 9px 5px;
   border: 1px solid #dedede;

--- a/src/styles/ErrorModal.css
+++ b/src/styles/ErrorModal.css
@@ -15,7 +15,7 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  z-index: 9999;
+  z-index: var(--error-modal-z-index);
 }
 
 .modal-button {

--- a/src/styles/InputTodo.css
+++ b/src/styles/InputTodo.css
@@ -38,11 +38,6 @@
   text-overflow: ellipsis;
 }
 
-.input-icon {
-  color: #7d7d7d;
-  font-size: 20px;
-}
-
 .input-submit {
   background: transparent;
   cursor: pointer;

--- a/src/styles/InputTodo.css
+++ b/src/styles/InputTodo.css
@@ -1,7 +1,3 @@
-.input-todo-container {
-  position: relative;
-  z-index: 999;
-}
 .form-container {
   display: flex;
   width: 100%;

--- a/src/styles/Main.css
+++ b/src/styles/Main.css
@@ -10,6 +10,7 @@
 .inner {
   width: 100%;
   padding: 8rem 10px 4rem;
+  position: relative;
 }
 
 .search-bar {


### PR DESCRIPTION
## PR Type 🚀

- [x] 리팩토링

## Description 📝

현재 props drilling 해결과 관심사 분리를 위해 Context API를 사용하고 있습니다.
[PR 12](https://github.com/wanted-pre-onboarding-team-9/pre-onboarding-10th-4-9/pull/12)에서 `Dropdown`의 위치가 `InputTodo` 컴포넌트 내에 위치하는 게 컴포넌트 네이밍과 추상화 수준에서 문제가 있다는 의견이 나와 컴포넌트 위치 변경을 진행했습니다.

Closes #38 

## Changes 🤖

- `InputTodo` 컴포넌트 내에 존재하는 `Dropdown` 컴포넌트를 Main 페이지로 이동하여 추상화 레벨을 일치시켰습니다.
- 구조 변경으로 인한 디자인 수정과 `SearchContextProvider` 위치가 같이 변경되었습니다.


## Screenshots 📸

| 기능   | 스크린샷 |
| ------ | :------: |
| 컴포넌트 구조 변경으로 인한 디자인 코드 수정 확인 용 |  <img width="675" alt="image" src="https://github.com/wanted-pre-onboarding-team-9/pre-onboarding-10th-4-9/assets/60846068/e498cf36-ef7d-4974-9982-ce484d823e2f">  |

## Test Checklist ✅

- [x] 검색어 입력 시 수정된 드롭다운 위치를 확인하였습니다.

## Other information 💬

- 해당 리팩토링으로 인해서 관련된 코드가 문제가 발생되는지 확인 부탁드립니다.
- 또한, 제가 작업한 디자인 코드가 올바르게 수정되었거나 누락이 없는지도 확인 부탁드립니다.
